### PR TITLE
Adding portable JSON support.

### DIFF
--- a/hello-eclipsecon/pom.xml
+++ b/hello-eclipsecon/pom.xml
@@ -82,6 +82,12 @@
 			<artifactId>jboss-servlet-api_3.0_spec</artifactId>
 			<scope>provided</scope>
 		</dependency>
+
+                <dependency>
+                    <groupId>org.codehaus.jackson</groupId>
+                    <artifactId>jackson-jaxrs</artifactId>
+                    <version>1.9.2</version>
+                </dependency>
 	</dependencies>
 
 	<build>


### PR DESCRIPTION
JAX-RS does not define JSON support. Jackson lib contains JSON message body writer/reader portable across different JAX-RS impls. Adding that to the project makes this demo portable to different JavaEE 6 app servers.
